### PR TITLE
Fix missing POSTGRES_URL error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,16 @@ XAI_API_KEY=****
 BLOB_READ_WRITE_TOKEN=****
 
 # Instructions to create a PostgreSQL database here: https://vercel.com/docs/storage/vercel-postgres/quickstart
+# POSTGRES_URL is used by default, but DATABASE_URL is also supported
 POSTGRES_URL=****
+# DATABASE_URL=
 
 
 # Instructions to create a Redis store here:
 # https://vercel.com/docs/redis
 REDIS_URL=****
+
+# Danckuts API configuration
+DANCKUTS_API_BASE_URL=http://atlas.danckuts.com
+DANCKUTS_API_TOKEN=****
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ You can deploy your own version of the Next.js AI Chatbot to Vercel with one cli
 
 You will need to use the environment variables [defined in `.env.example`](.env.example) to run Next.js AI Chatbot. It's recommended you use [Vercel Environment Variables](https://vercel.com/docs/projects/environment-variables) for this, but a `.env` file is all that is necessary.
 
+> **Database URL**: the app expects `POSTGRES_URL` for the Postgres connection. If
+> your provider (such as Vercel Postgres) supplies a `DATABASE_URL` variable,
+> rename it or duplicate it as `POSTGRES_URL` so migrations can run during the
+> build step.
+
 > Note: You should not commit your `.env` file or it will expose secrets that will allow others to control access to your various AI and authentication provider accounts.
 
 1. Install Vercel CLI: `npm i -g vercel`

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -23,6 +23,7 @@ import { createDocument } from '@/lib/ai/tools/create-document';
 import { updateDocument } from '@/lib/ai/tools/update-document';
 import { requestSuggestions } from '@/lib/ai/tools/request-suggestions';
 import { getWeather } from '@/lib/ai/tools/get-weather';
+import { danckutsTools } from '@/lib/ai/tools/danckuts';
 import { isProductionEnvironment } from '@/lib/constants';
 import { myProvider } from '@/lib/ai/providers';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
@@ -159,6 +160,17 @@ export async function POST(request: Request) {
                   'createDocument',
                   'updateDocument',
                   'requestSuggestions',
+                  'getUserProfile',
+                  'getAllLocations',
+                  'checkPhoneNumberHasUser',
+                  'sendTextCode',
+                  'verifyTextCode',
+                  'getRecentAppointments',
+                  'cancelAppointment',
+                  'getAppointmentAvailability',
+                  'rescheduleAppointment',
+                  'scheduleAppointment',
+                  'showOptions',
                 ],
           experimental_transform: smoothStream({ chunking: 'word' }),
           experimental_generateMessageId: generateUUID,
@@ -170,6 +182,7 @@ export async function POST(request: Request) {
               session,
               dataStream,
             }),
+            ...danckutsTools,
           },
           onFinish: async ({ response }) => {
             if (session.user?.id) {

--- a/components/availability.tsx
+++ b/components/availability.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { format } from 'date-fns';
+import { OptionButtons } from './option-buttons';
+
+interface Availability {
+  dates: Record<string, string[]>;
+  slots: Record<string, Record<string, number>>;
+}
+
+export function AvailabilityDisplay({
+  availability,
+  onSelect,
+}: {
+  availability: Availability;
+  onSelect: (iso: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      {Object.entries(availability.slots).map(([date, times]) => (
+        <div key={date} className="flex flex-col gap-2">
+          <div className="font-medium">
+            {format(new Date(date), 'PPP')}
+          </div>
+          <OptionButtons
+            options={Object.keys(times).map((iso) =>
+              format(new Date(iso), 'p'),
+            )}
+            onSelect={(label) => {
+              const iso = Object.keys(times).find(
+                (t) => format(new Date(t), 'p') === label,
+              );
+              if (iso) onSelect(iso);
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -134,6 +134,7 @@ export function Chat({
           messages={messages}
           setMessages={setMessages}
           reload={reload}
+          append={append}
           isReadonly={isReadonly}
           isArtifactVisible={isArtifactVisible}
         />

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -11,6 +11,9 @@ import { Markdown } from './markdown';
 import { MessageActions } from './message-actions';
 import { PreviewAttachment } from './preview-attachment';
 import { Weather } from './weather';
+import { OptionButtons } from './option-buttons';
+import { AvailabilityDisplay } from './availability';
+import { ProfileCard } from './profile-card';
 import equal from 'fast-deep-equal';
 import { cn, sanitizeText } from '@/lib/utils';
 import { Button } from './ui/button';
@@ -27,6 +30,7 @@ const PurePreviewMessage = ({
   isLoading,
   setMessages,
   reload,
+  append,
   isReadonly,
   requiresScrollPadding,
 }: {
@@ -36,6 +40,7 @@ const PurePreviewMessage = ({
   isLoading: boolean;
   setMessages: UseChatHelpers['setMessages'];
   reload: UseChatHelpers['reload'];
+  append: UseChatHelpers['append'];
   isReadonly: boolean;
   requiresScrollPadding: boolean;
 }) => {
@@ -212,6 +217,31 @@ const PurePreviewMessage = ({
                           result={result}
                           isReadonly={isReadonly}
                         />
+                      ) : toolName === 'showOptions' ? (
+                        <OptionButtons
+                          options={result.options}
+                          onSelect={(value) =>
+                            append({ role: 'user', content: value })
+                          }
+                        />
+                      ) : toolName === 'getAllLocations' ? (
+                        <OptionButtons
+                          options={result.payload.locations.map(
+                            (l: any) => l.location,
+                          )}
+                          onSelect={(value) =>
+                            append({ role: 'user', content: value })
+                          }
+                        />
+                      ) : toolName === 'getAppointmentAvailability' ? (
+                        <AvailabilityDisplay
+                          availability={result.payload}
+                          onSelect={(iso) =>
+                            append({ role: 'user', content: iso })
+                          }
+                        />
+                      ) : toolName === 'getUserProfile' ? (
+                        <ProfileCard user={result.payload.user} />
                       ) : (
                         <pre>{JSON.stringify(result, null, 2)}</pre>
                       )}

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -15,6 +15,7 @@ interface MessagesProps {
   messages: Array<UIMessage>;
   setMessages: UseChatHelpers['setMessages'];
   reload: UseChatHelpers['reload'];
+  append: UseChatHelpers['append'];
   isReadonly: boolean;
   isArtifactVisible: boolean;
 }
@@ -26,6 +27,7 @@ function PureMessages({
   messages,
   setMessages,
   reload,
+  append,
   isReadonly,
 }: MessagesProps) {
   const {
@@ -59,6 +61,7 @@ function PureMessages({
           }
           setMessages={setMessages}
           reload={reload}
+          append={append}
           isReadonly={isReadonly}
           requiresScrollPadding={
             hasSentMessage && index === messages.length - 1

--- a/components/option-buttons.tsx
+++ b/components/option-buttons.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Button } from './ui/button';
+import { motion } from 'framer-motion';
+
+interface OptionButtonsProps {
+  options: Array<string>;
+  onSelect: (value: string) => void;
+}
+
+export function OptionButtons({ options, onSelect }: OptionButtonsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((option, index) => (
+        <motion.div
+          key={option}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0, transition: { delay: 0.05 * index } }}
+        >
+          <Button variant="outline" onClick={() => onSelect(option)}>
+            {option}
+          </Button>
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/components/profile-card.tsx
+++ b/components/profile-card.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Image from 'next/image';
+
+interface UserProfile {
+  name: string;
+  profileImage: string;
+  recentCuts?: Array<string>;
+}
+
+export function ProfileCard({ user }: { user: UserProfile }) {
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <Image
+        src={user.profileImage}
+        alt={`${user.name} profile`}
+        width={80}
+        height={80}
+        className="rounded-full"
+      />
+      <div className="font-medium">{user.name}</div>
+      {user.recentCuts && user.recentCuts.length > 0 && (
+        <div className="flex gap-2">
+          {user.recentCuts.map((url) => (
+            <Image
+              key={url}
+              src={url}
+              alt="Recent cut"
+              width={60}
+              height={60}
+              className="rounded-md"
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
   out: './lib/db/migrations',
   dialect: 'postgresql',
   dbCredentials: {
+    // Allow DATABASE_URL as a fallback for POSTGRES_URL
     // biome-ignore lint: Forbidden non-null assertion.
-    url: process.env.POSTGRES_URL!,
+    url: (process.env.POSTGRES_URL || process.env.DATABASE_URL)!,
   },
 });

--- a/lib/ai/tools/danckuts.ts
+++ b/lib/ai/tools/danckuts.ts
@@ -1,0 +1,93 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import {
+  getUserProfile,
+  getAllLocations,
+  checkPhoneNumberHasUser,
+  sendTextCode,
+  verifyTextCode,
+  getRecentAppointments,
+  cancelAppointment,
+  getAppointmentAvailability,
+  rescheduleAppointment,
+  scheduleAppointment,
+} from '@/lib/api/danckuts';
+
+export const danckutsTools = {
+  getUserProfile: tool({
+    description: 'Retrieve the authenticated user profile',
+    parameters: z.object({ token: z.string() }),
+    execute: async ({ token }) => getUserProfile(token),
+  }),
+  getAllLocations: tool({
+    description: 'Get list of all salon locations',
+    parameters: z.object({ token: z.string() }),
+    execute: async ({ token }) => getAllLocations(token),
+  }),
+  checkPhoneNumberHasUser: tool({
+    description: 'Check if a phone number has an account',
+    parameters: z.object({ phoneNumber: z.string() }),
+    execute: async ({ phoneNumber }) => checkPhoneNumberHasUser(phoneNumber),
+  }),
+  sendTextCode: tool({
+    description: 'Send authentication text code',
+    parameters: z.object({ phoneNumber: z.string() }),
+    execute: async ({ phoneNumber }) => sendTextCode(phoneNumber),
+  }),
+  verifyTextCode: tool({
+    description: 'Verify authentication text code',
+    parameters: z.object({ phoneNumber: z.string(), code: z.string() }),
+    execute: async ({ phoneNumber, code }) => verifyTextCode(phoneNumber, code),
+  }),
+  getRecentAppointments: tool({
+    description: 'Retrieve user appointments',
+    parameters: z.object({ token: z.string() }),
+    execute: async ({ token }) => getRecentAppointments(token),
+  }),
+  cancelAppointment: tool({
+    description: 'Cancel an appointment',
+    parameters: z.object({ token: z.string(), appointmentId: z.number() }),
+    execute: async ({ token, appointmentId }) =>
+      cancelAppointment(token, appointmentId),
+  }),
+  getAppointmentAvailability: tool({
+    description: 'Get appointment availability for location and dates',
+    parameters: z.object({
+      token: z.string(),
+      location: z.string(),
+      dates: z.array(z.string()).optional(),
+    }),
+    execute: async ({ token, location, dates }) =>
+      getAppointmentAvailability(token, location, dates),
+  }),
+  rescheduleAppointment: tool({
+    description: 'Reschedule an appointment',
+    parameters: z.object({
+      token: z.string(),
+      appointmentId: z.string(),
+      location: z.string(),
+      time: z.string(),
+    }),
+    execute: async ({ token, appointmentId, location, time }) =>
+      rescheduleAppointment(token, appointmentId, location, time),
+  }),
+  scheduleAppointment: tool({
+    description: 'Schedule a new appointment',
+    parameters: z.object({
+      token: z.string(),
+      location: z.string(),
+      time: z.string(),
+      dependentId: z.number().optional(),
+      serviceType: z.string().optional(),
+    }),
+    execute: async ({ token, location, time, dependentId, serviceType }) =>
+      scheduleAppointment(token, location, time, dependentId, serviceType),
+  }),
+  showOptions: tool({
+    description: 'Render selectable options to the user',
+    parameters: z.object({
+      options: z.array(z.string()),
+    }),
+    execute: async ({ options }) => ({ options }),
+  }),
+};

--- a/lib/api/danckuts.ts
+++ b/lib/api/danckuts.ts
@@ -1,0 +1,103 @@
+const BASE_URL = process.env.DANCKUTS_API_BASE_URL || 'http://atlas.danckuts.com';
+
+async function request(path: string, options: RequestInit = {}, token?: string) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${BASE_URL}${path}`, { ...options, headers });
+  if (!res.ok) {
+    throw new Error(`Danckuts API error: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function getUserProfile(token: string) {
+  return request('/api/auth/me', { method: 'GET' }, token);
+}
+
+export async function getAllLocations(token: string) {
+  return request('/api/locations/hidden', { method: 'GET' }, token);
+}
+
+export async function checkPhoneNumberHasUser(phoneNumber: string) {
+  return request('/api/auth/phone-number-has-user', {
+    method: 'POST',
+    body: JSON.stringify({ phoneNumber }),
+  });
+}
+
+export async function sendTextCode(phoneNumber: string) {
+  return request('/api/auth/send-text-code', {
+    method: 'POST',
+    body: JSON.stringify({ phoneNumber }),
+  });
+}
+
+export async function verifyTextCode(phoneNumber: string, code: string) {
+  return request('/api/auth/check-text-code', {
+    method: 'POST',
+    body: JSON.stringify({ phoneNumber, code }),
+  });
+}
+
+export async function getRecentAppointments(token: string) {
+  return request('/api/appointments/recent', { method: 'GET' }, token);
+}
+
+export async function cancelAppointment(token: string, appointmentId: number) {
+  return request(
+    '/api/appointments/cancel',
+    {
+      method: 'POST',
+      body: JSON.stringify({ appointmentId }),
+    },
+    token,
+  );
+}
+
+export async function getAppointmentAvailability(
+  token: string,
+  location: string,
+  dates?: string[],
+) {
+  const params = new URLSearchParams();
+  params.set('location', location);
+  if (dates) {
+    for (const d of dates) params.append('dates', d);
+  }
+  return request(`/api/time/availability?${params.toString()}`, { method: 'GET' }, token);
+}
+
+export async function rescheduleAppointment(
+  token: string,
+  appointmentId: string,
+  location: string,
+  time: string,
+) {
+  return request(
+    '/api/appointments/reschedule',
+    {
+      method: 'POST',
+      body: JSON.stringify({ appointmentId, location, time }),
+    },
+    token,
+  );
+}
+
+export async function scheduleAppointment(
+  token: string,
+  location: string,
+  time: string,
+  dependentId?: number,
+  serviceType?: string,
+) {
+  return request(
+    '/api/appointments/schedule',
+    {
+      method: 'POST',
+      body: JSON.stringify({ location, time, dependentId, serviceType }),
+    },
+    token,
+  );
+}

--- a/lib/db/helpers/01-core-to-parts.ts
+++ b/lib/db/helpers/01-core-to-parts.ts
@@ -16,11 +16,12 @@ config({
   path: '.env.local',
 });
 
-if (!process.env.POSTGRES_URL) {
-  throw new Error('POSTGRES_URL environment variable is not set');
+const DB_URL = process.env.POSTGRES_URL || process.env.DATABASE_URL;
+if (!DB_URL) {
+  throw new Error('POSTGRES_URL or DATABASE_URL environment variable is not set');
 }
 
-const client = postgres(process.env.POSTGRES_URL);
+const client = postgres(DB_URL);
 const db = drizzle(client);
 
 const BATCH_SIZE = 100; // Process 100 chats at a time

--- a/lib/db/migrate.ts
+++ b/lib/db/migrate.ts
@@ -8,11 +8,12 @@ config({
 });
 
 const runMigrate = async () => {
-  if (!process.env.POSTGRES_URL) {
-    throw new Error('POSTGRES_URL is not defined');
+  const DB_URL = process.env.POSTGRES_URL || process.env.DATABASE_URL;
+  if (!DB_URL) {
+    throw new Error('POSTGRES_URL or DATABASE_URL is not defined');
   }
 
-  const connection = postgres(process.env.POSTGRES_URL, { max: 1 });
+  const connection = postgres(DB_URL, { max: 1 });
   const db = drizzle(connection);
 
   console.log('⏳ Running migrations...');

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -39,7 +39,7 @@ import { ChatSDKError } from '../errors';
 // https://authjs.dev/reference/adapter/drizzle
 
 // biome-ignore lint: Forbidden non-null assertion.
-const client = postgres(process.env.POSTGRES_URL!);
+const client = postgres((process.env.POSTGRES_URL || process.env.DATABASE_URL)!);
 const db = drizzle(client);
 
 export async function getUser(email: string): Promise<Array<User>> {


### PR DESCRIPTION
## Summary
- clarify database variable handling in README and `.env.example`
- accept `DATABASE_URL` as a fallback for `POSTGRES_URL` in database scripts

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*

## Summary by Sourcery

Use DATABASE_URL as a fallback for POSTGRES_URL across DB scripts and configs, and extend the chat with Danckuts API tools—adding backend integrations and front-end components for interactive profile, location, and appointment workflows.

New Features:
- Accept DATABASE_URL as a fallback for POSTGRES_URL in database connections and migrations
- Integrate Danckuts API tools for user profile, location lookup, phone number checks, authentication codes, and appointment management into the chat backend
- Add client components (OptionButtons, AvailabilityDisplay, ProfileCard) and wire them into the chat UI to render interactive tool results

Bug Fixes:
- Combine POSTGRES_URL and DATABASE_URL checks and update error message when neither is set

Enhancements:
- Update README and .env.example to document the DATABASE_URL fallback for Postgres
- Propagate the append helper through chat and message components to support new interaction flows

Documentation:
- Clarify database environment variable handling in user-facing documentation