### PR TITLE
Add cycling status indicator

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -162,3 +162,12 @@
 .suggestion-highlight {
     @apply bg-blue-200 hover:bg-blue-300 dark:hover:bg-blue-400/50 dark:text-blue-50 dark:bg-blue-500/40;
 }
+@keyframes dot-bounce {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-0.25rem); }
+}
+
+.bounce-dot {
+  display: inline-block;
+  animation: dot-bounce 1s infinite;
+}

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -3,7 +3,7 @@
 import type { UIMessage } from 'ai';
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
-import { memo, useState } from 'react';
+import { memo, useState, useEffect } from 'react';
 import type { Vote } from '@/lib/db/schema';
 import { DocumentToolCall, DocumentToolResult } from './document';
 import { PencilEditIcon, SparklesIcon } from './icons';
@@ -283,6 +283,16 @@ export const PreviewMessage = memo(
 
 export const ThinkingMessage = () => {
   const role = 'assistant';
+  const statuses = ['Analyzing', 'Reasoning', 'Responding'];
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => setIndex((i) => (i + 1) % statuses.length),
+      2000,
+    );
+    return () => clearInterval(interval);
+  }, [statuses.length]);
 
   return (
     <motion.div
@@ -304,9 +314,14 @@ export const ThinkingMessage = () => {
           <SparklesIcon size={14} />
         </div>
 
-        <div className="flex flex-col gap-2 w-full">
-          <div className="flex flex-col gap-4 text-muted-foreground">
-            Hmm...
+        <div className="flex flex-col gap-2 w-full" data-testid="status-text">
+          <div className="flex items-center gap-1 text-muted-foreground">
+            {statuses[index]}
+            <span className="ml-1" data-testid="bouncing-dots">
+              <span className="bounce-dot">.</span>
+              <span className="bounce-dot" style={{ animationDelay: '0.2s' }}>.</span>
+              <span className="bounce-dot" style={{ animationDelay: '0.4s' }}>.</span>
+            </span>
           </div>
         </div>
       </div>

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -17,6 +17,18 @@ test.describe('Chat activity', () => {
     expect(assistantMessage.content).toContain("It's just green duh!");
   });
 
+  test('Status indicator cycles while waiting', async ({ page }) => {
+    await chatPage.sendUserMessage('Why is grass green?');
+
+    await expect(chatPage.thinkingMessage).toBeVisible();
+    const firstStatus = await chatPage.getStatusText();
+    await page.waitForTimeout(2100);
+    const secondStatus = await chatPage.getStatusText();
+    expect(firstStatus).not.toBe(secondStatus);
+
+    await chatPage.isGenerationComplete();
+  });
+
   test('Redirect to /chat/:id after submitting message', async () => {
     await chatPage.sendUserMessage('Why is grass green?');
     await chatPage.isGenerationComplete();

--- a/tests/pages/chat.ts
+++ b/tests/pages/chat.ts
@@ -26,6 +26,14 @@ export class ChatPage {
     return this.page.getByTestId('scroll-to-bottom-button');
   }
 
+  public get thinkingMessage() {
+    return this.page.getByTestId('message-assistant-loading');
+  }
+
+  public async getStatusText() {
+    return this.thinkingMessage.getByTestId('status-text').innerText();
+  }
+
   async createNewChat() {
     await this.page.goto('/');
   }


### PR DESCRIPTION
## Summary
- animate lucy's status with bouncing dots
- define bounce-dot animation in globals
- test status indicator cycle

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*
- `pnpm exec playwright test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

## Summary by Sourcery

Introduce a dynamic cycling status indicator in the assistant's ThinkingMessage component with bouncing dots and update tests to validate its behavior.

New Features:
- Animate the assistant's thinking message by cycling through 'Analyzing', 'Reasoning', and 'Responding' statuses with bouncing dots every 2 seconds.

Enhancements:
- Add global CSS keyframes and a .bounce-dot class to define the dot-bounce animation.

Tests:
- Add an E2E test to verify the status indicator cycles during message generation.
- Extend ChatPage page object with thinkingMessage and getStatusText helpers for testing.